### PR TITLE
Return profile object including user's display name after registration

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -50,7 +50,7 @@ OAuth.registerService(Microsoft.serviceName, 2, null, function({ code }) {
 
     return {
         serviceData: serviceData,
-        // options: {profile: {name: identity.name}}
+        options: {profile: {name: identity.displayName}}
     };
 });
 


### PR DESCRIPTION
Small tweak to return a profile object containing the user's display name after registration. 

'displayName' appears to be the correct attribute to use here. It worked with my testing and is documented in the graph API here: http://graph.microsoft.io/en-us/docs/api-reference/beta/resources/user

What do you think @gwhobbs ?
